### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,10 +5,18 @@ set INCLUDE=%LIBRARY_INC%;%INCLUDE%;%RECIPE_DIR%
 mkdir build_dir
 cd build_dir
 
+:: Moving changes from patch here to avoid errors with patching on windows. 
+:: Files have a different line ending and patch doesn't work well with that.
+python -c "
+content = open('hdf/src/hlimits.h').read()
+content = content.replace('#   define MAX_FILE   32', '#   define MAX_FILE   4096')
+open('hdf/src/hlimits.h', 'w').write(content)
+"
+
 :: Configure step.
 cmake -G "%CMAKE_GENERATOR%" ^
       -D CMAKE_BUILD_TYPE=Release ^
-      :: -D HDF4_BUILD_HL_LIB=ON ^
+      -D CMAKE_POLICY_VERSION_MINIMUM=3.5 ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D ZLIB_DIR=%LIBRARY_PREFIX% ^
       -D JPEG_DIR=%LIBRARY_PREFIX% ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-# export CFLAGS="${CFLAGS} -Wno-error=implicit-function-declaration -Wno-error=incompatible-function-pointer-types -Wno-error=incompatible-pointer-types"
+export CFLAGS="${CFLAGS} -Wno-error=implicit-function-declaration \
+                        -Wno-error=incompatible-pointer-types \
+                        -Wno-error=implicit-int"
+if [[ "$(uname)" == "Linux" ]]; then
+  export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include/tirpc"
+  export LDFLAGS="${LDFLAGS} -ltirpc"
+fi
+if [[ "$(uname)" == "Darwin" ]]; then
+  export LDFLAGS="${LDFLAGS} -Wl,-flat_namespace -Wl,-undefined,suppress"
+fi
+
 autoreconf -vfi
 
 # The --enable-silent-rules is needed because Travis CI dies on the long output from this build.
@@ -9,25 +19,23 @@ if [[ $(uname -m) == "aarch64" ]]; then
 ./configure --prefix=${PREFIX}\
             --host=aarch64-linux-gnu \
             --build=aarch64-linux-gnu \
-            --enable-linux-lfs \
             --enable-silent-rules \
             --enable-shared \
-            --with-ssl \
             --with-zlib \
             --with-jpeg \
             --disable-netcdf \
-            --disable-fortran
+            --disable-hdf4-xdr \
+            --disable-fortran || (cat config.log; exit 1)
 else
 ./configure --prefix=${PREFIX}\
             --host=$HOST \
-            --enable-linux-lfs \
             --enable-silent-rules \
             --enable-shared \
-            --with-ssl \
             --with-zlib \
             --with-jpeg \
             --disable-netcdf \
-            --disable-fortran
+            --disable-hdf4-xdr \
+            --disable-fortran || (cat config.log; exit 1)
 fi
 
 # make sure that linux aarch64 configuration is defined ...

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# export CFLAGS="${CFLAGS} -Wno-error=implicit-function-declaration -Wno-error=incompatible-function-pointer-types -Wno-error=incompatible-pointer-types"
 autoreconf -vfi
 
 # The --enable-silent-rules is needed because Travis CI dies on the long output from this build.

--- a/recipe/disable_xdr.patch
+++ b/recipe/disable_xdr.patch
@@ -1,0 +1,24 @@
+diff --git a/configure.ac b/configure.ac
+index 3030bad3d..525d582eb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -664,8 +664,9 @@ AC_ARG_ENABLE([hdf4-xdr],
+               [AS_HELP_STRING([--enable-hdf4-xdr],
+                               [Build xdr library from code in HDF4 source.
+                                Not supported for 64 bit mode. [default="no"]])],
+-              [enableval="yes"],[enableval="no"])
++              [],[enableval="no"])
+ 
++user_set_xdr="$enableval"
+ case "$enableval" in
+   yes)
+     BUILD_XDR="yes"
+@@ -693,7 +694,7 @@ if test "X$BUILD_XDR" != "Xyes"; then
+     #include <rpc/types.h>
+     #include <rpc/xdr.h>], [xdr_int],
+                 [AC_MSG_RESULT([yes]); BUILD_XDR="no"],
+-                [AC_MSG_RESULT([no]); BUILD_XDR="yes"])
++                [AC_MSG_RESULT([no]); if test "X$user_set_xdr" != "Xno"; then BUILD_XDR="yes"; fi])
+ fi
+ 
+ AM_CONDITIONAL([HDF_BUILD_XDR], [test "X$BUILD_XDR" = "Xyes"])

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,13 @@ package:
 
 source:
     fn: hdf-{{ version }}.tar.bz2
-    url: http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-{{ version }}.tar.bz2
+    url: https://support.hdfgroup.org/ftp/HDF/releases/HDF{{ version }}/src/hdf-{{ version }}.tar.bz2
     sha256: 55d3a42313bda0aba7b0463687caf819a970e0ba206f5ed2c23724f80d2ae0f3
     patches:
         - max_files.patch
 
 build:
-    number: 3
+    number: 4
     run_exports:
         # change SONAMEs with bugfix rev.
         #    https://abi-laboratory.pro/tracker/timeline/hdf5/
@@ -31,21 +31,20 @@ requirements:
         - autoconf    # [unix]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - patch       # [not win]
-        - m2-patch    # [win]
     host:
         - msinttypes  # [win and vc<14]
-        - zlib
-        - jpeg
-    # run:
+        - zlib {{ zlib }}
+        - libjpeg-turbo {{ libjpeg_turbo }}
+    run:
         # zlib removed here because zlib package has run_exports for itself
         #    https://github.com/AnacondaRecipes/hdf5-feedstock/pull/1/files#diff-e178b687b10a71a3348107ae3154e44cR31
         # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
-        # - zlib 1.2.*
+        - zlib
         # jpeg removed here because package has run_exports for itself
         #    https://github.com/AnacondaRecipes/jpeg-feedstock/pull/1
         # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
         #- jpeg 9*
+        - libjpeg-turbo
 
 test:
     commands:
@@ -64,9 +63,14 @@ test:
 about:
     home: http://www.hdfgroup.org/HDF4/
     license: BSD 3-Clause
-    summary: 'Library and multi-object file format for storing and managing data between machines.'
+    summary: Library and multi-object file format for storing and managing data between machines.
+    description: |
+        HDF4 is a library and multi-object file format for storing and managing data between machines. 
+        There are two versions of HDF technologies that are completely different: HDF4 and HDF5. HDF4 is the first HDF format.
     license_family: BSD
     license_file: COPYING
+    doc_url: https://support.hdfgroup.org/release4/doc/index.html
+    dev_url: https://github.com/HDFGroup/hdf4
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,9 @@ source:
     fn: hdf-{{ version }}.tar.bz2
     url: https://support.hdfgroup.org/ftp/HDF/releases/HDF{{ version }}/src/hdf-{{ version }}.tar.bz2
     sha256: 55d3a42313bda0aba7b0463687caf819a970e0ba206f5ed2c23724f80d2ae0f3
-    patches:
-        - max_files.patch
+    patches:                # [unix]
+        - max_files.patch   # [unix]
+        - disable_xdr.patch # [unix]
 
 build:
     number: 4
@@ -35,16 +36,16 @@ requirements:
         - msinttypes  # [win and vc<14]
         - zlib {{ zlib }}
         - libjpeg-turbo {{ libjpeg_turbo }}
+        - libtirpc {{ libtirpc }}  # [unix]
     run:
         # zlib removed here because zlib package has run_exports for itself
         #    https://github.com/AnacondaRecipes/hdf5-feedstock/pull/1/files#diff-e178b687b10a71a3348107ae3154e44cR31
         # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
-        - zlib
-        # jpeg removed here because package has run_exports for itself
-        #    https://github.com/AnacondaRecipes/jpeg-feedstock/pull/1
+        # - zlib
+        # libjpeg-turbo removed here because package has run_exports for itself
+        #    https://github.com/AnacondaRecipes/libjpeg-turbo-feedstock/blob/e5541bfba61b85797f75d0da807674354363fa45/recipe/meta.yaml#L15
         # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
-        #- jpeg 9*
-        - libjpeg-turbo
+        # - libjpeg-turbo
 
 test:
     commands:


### PR DESCRIPTION
hdf4 4.2.13

**Destination channel:**  defaults

### Links

- [PKG-13226](https://anaconda.atlassian.net/browse/PKG-13226) 
- [Upstream repository](https://github.com/HDFGroup/hdf4)
### Explanation of changes:
- Rebuild against libjpeg-turbo
- XDR configure logic bug on 64-bit systems: configure.ac forced BUILD_XDR=yes when system XDR headers were missing, ignoring --disable-hdf4-xdr. Fixed via disable_xdr.patch.
- Missing RPC headers on modern Linux (glibc 2.26+): rpc/types.h was removed from glibc and moved to libtirpc. Added libtirpc to host/run dependencies and updated CPPFLAGS/LDFLAGS accordingly.


[PKG-13226]: https://anaconda.atlassian.net/browse/PKG-13226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ